### PR TITLE
Updated inert to version 3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "hapi": "10.1.0",
     "hapi-mustache": "0.0.1",
     "history": "1.11.0",
-    "inert": "3.0.1",
+    "inert": "3.0.2",
     "jsx-require-extension": "0.2.0",
     "lodash": "3.10.1",
     "negotiator": "0.6.0",


### PR DESCRIPTION
:rocket:

inert just published version 3.0.2, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 5 commits (ahead by 5, behind by 0).

- [a65c731](https://github.com/hapijs/inert/commit/a65c7317e14d150e98b2e7b201926b15cc723dcb): 3.0.2
- [10c7a3a](https://github.com/hapijs/inert/commit/10c7a3a6d1342ab6b6cc6f8f4390240b035f8b9d): Merge pull request #42 from kanongil/no-dir-file-reopen
- [6a5c425](https://github.com/hapijs/inert/commit/6a5c42529f854133f079012038b88de2dfef0d8f): Avoid re-opening files when serving from a directory
- [19e28fc](https://github.com/hapijs/inert/commit/19e28fcdab2fc4e1a7acc04a0e0162da9ba9ece4): Refactor to use new Joi.attempt method
- [f43eb46](https://github.com/hapijs/inert/commit/f43eb466c978de15c0863686866a6b303108f106): Test using node 4.0

See the [full diff](https://github.com/hapijs/inert/compare/407740508e95aa529b3affdb4ec185607dfc3e7f...a65c7317e14d150e98b2e7b201926b15cc723dcb).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>