### PR TITLE
Updated grunt-shell-spawn to version 0.3.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "grunt-mocha-cov": "0.4.0",
     "grunt-perfbudget": "0.1.6",
     "grunt-sass": "1.0.0",
-    "grunt-shell-spawn": "0.3.9",
+    "grunt-shell-spawn": "0.3.10",
     "grunt-wait": "0.1.0",
     "jsdom": "6.5.1",
     "load-grunt-config": "0.17.2",


### PR DESCRIPTION
:rocket:

grunt-shell-spawn just published version 0.3.10, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 4 commits (ahead by 4, behind by 0).

- [31b2308](https://github.com/cri5ti/grunt-shell-spawn/commit/31b2308b631bfae8d8b3f92e6009cb82c6b0b044): Version bump to 0.3.10
- [d9ca495](https://github.com/cri5ti/grunt-shell-spawn/commit/d9ca495b0d6881274714dbe0db7fe390f79a9212): Merge researchgate/master. Closes #39
- [347004e](https://github.com/cri5ti/grunt-shell-spawn/commit/347004ea9ca383c88a3a6a4b426a8f391637c1e4): Remove duplicated code
- [8cf55a6](https://github.com/cri5ti/grunt-shell-spawn/commit/8cf55a650658819ea7cdba612ca99ade2f2080d2): Add SIGINT handler that kills child process and also use killPid function in SIGINT and exit handlers to reliably kill child process without leaving orphans

See the [full diff](https://github.com/cri5ti/grunt-shell-spawn/compare/d7084d22e9a080830c4793b5b6ac2a01cf373b1c...31b2308b631bfae8d8b3f92e6009cb82c6b0b044).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>