### PR TITLE
Updated history to version 1.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "director": "1.2.8",
     "hapi": "10.3.0",
     "hapi-mustache": "0.0.1",
-    "history": "1.11.0",
+    "history": "1.12.0",
     "inert": "3.0.1",
     "jsx-require-extension": "0.2.0",
     "lodash": "3.10.1",


### PR DESCRIPTION
:rocket:

history just published version 1.12.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 19 commits (ahead by 19, behind by 0).

- [de6febd](https://github.com/rackt/history/commit/de6febdf33fca3a62954ea39ff5bb6d6967e8c3b): Version 1.12.0
- [a78a156](https://github.com/rackt/history/commit/a78a15647ce3656d7c38afefd56bebedf0c75262): Merge pull request #79 from rackt/create-location
- [21f8dbd](https://github.com/rackt/history/commit/21f8dbdeaec458538882f72a4c5a5c2fad2b34da): Make createLocation an instance method
- [7107009](https://github.com/rackt/history/commit/7107009ed818aa78e3e1923370d1b067277455b7): Better method name
- [17c1576](https://github.com/rackt/history/commit/17c1576b5b2bd6a1ec0884ede95fb8a74145dfb8): Merge pull request #78 from djkirby/patch-1
- [c41e5d4](https://github.com/rackt/history/commit/c41e5d498b2f8aff39a9cac6e2b109edb3aae876): :memo: Fix typo in docs
- [51b199c](https://github.com/rackt/history/commit/51b199cbf43caefef0c13080a9299fbe3ec93816): Version 1.11.1
- [feb8412](https://github.com/rackt/history/commit/feb8412288778a3744bf1391892d9cfd15a0b753): Allow transitions to be interrupted by another
- [e7f5c47](https://github.com/rackt/history/commit/e7f5c47dfa4df94745359795ffd32572fb68fc75): Update syntax
- [797a51a](https://github.com/rackt/history/commit/797a51a8f4a2107c603fa614de4e44a2702d6a13): Merge pull request #44 from AndreasHogstrom/master
- [e0973cd](https://github.com/rackt/history/commit/e0973cd9adfeeeca5cf379c5b88224b9c50b52f8): Fix syntax
- [9573fe8](https://github.com/rackt/history/commit/9573fe85015acc22380585802aa868b6c75e569a): Merge pull request #69 from jesenko/patch-1
- [59863ab](https://github.com/rackt/history/commit/59863ab3e062d4d203f6a4cfd9a028d78c10ec18): Update ESLint rules
- [e43ba9d](https://github.com/rackt/history/commit/e43ba9dca668106d95aca1582b520863130a326b): Set pathname to '/' when stripped pathname is empty
- [70c61ae](https://github.com/rackt/history/commit/70c61ae86cf88cfb5669ca811b9e931103e0a0b6): Update syntax


There are 19 commits in total. See the [full diff](https://github.com/rackt/history/compare/6d0fc697ec65ad8c72042aa67c5d17025bdedcd9...de6febdf33fca3a62954ea39ff5bb6d6967e8c3b).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>