### PR TITLE
Revert "Update newrelic to version 1.27.0 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "inert": "3.2.0",
     "lodash": "4.11.1",
     "negotiator": "0.6.0",
-    "newrelic": "1.27.0",
+    "newrelic": "1.26.2",
     "react": "15.0.1",
     "react-bootstrap": "0.29.0",
     "react-dom": "15.0.1",


### PR DESCRIPTION
Reverts travi/travi.org-admin#462 because it appears that the version was unpublished